### PR TITLE
Fix issue #7: Bulk cancel is not owner-scoped and cancels other users' open tasks

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -168,10 +168,14 @@ def reassign_task_owner(db: Session, task: Task, new_owner_id: int) -> Task:
 
 def bulk_cancel_open_tasks(db: Session, owner_id: int) -> int:
     """Cancel all open tasks for a specific owner."""
-    # BUG #6: Missing owner filter; this can cancel tasks for all users.
+    # FIXED: Added owner_id filter to only cancel tasks for the specified owner
     open_tasks = (
         db.query(Task)
-        .filter(Task.status != TaskStatus.DONE, Task.status != TaskStatus.CANCELLED)
+        .filter(
+            Task.owner_id == owner_id,
+            Task.status != TaskStatus.DONE,
+            Task.status != TaskStatus.CANCELLED
+        )
         .all()
     )
 


### PR DESCRIPTION
## Description

Fixes issue #7: Bulk cancel is not owner-scoped and cancels other users' open tasks.

## Problem
The  function was missing the  filter in its database query, allowing any user to cancel ALL open tasks in the system, not just their own. This is a security and data integrity issue.

## Solution
Added  filter to the query in  to ensure bulk cancel operations only affect tasks belonging to the specified owner.

## Changes
- Modified  function in 
- Added owner_id filter alongside existing status filters
- Maintains same function signature and return value

## Testing
The fix ensures that:
- User A can only cancel their own open tasks
- User B's tasks remain unaffected when User A performs bulk cancel
- The function still correctly counts and returns the number of cancelled tasks

## Security Impact
This fix prevents unauthorized cancellation of other users' tasks, maintaining proper data isolation between users.

Fixes: #7