### PR TITLE
fix: defer task uses timedelta(days) not timedelta(hours)

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -145,8 +145,8 @@ def defer_task_due_date(db: Session, task: Task, days: int) -> Task:
     """Move a task due date forward by the provided day count."""
     base_due = task.due_date or datetime.utcnow()
 
-    # BUG #4: Should defer by whole days, but this uses hours.
-    task.due_date = base_due + timedelta(hours=days)
+    # Defer by the specified number of whole days.
+    task.due_date = base_due + timedelta(days=days)
     task.updated_at = datetime.utcnow()
     db.commit()
     db.refresh(task)


### PR DESCRIPTION
## Summary

Fixes #5

### Root Cause
`defer_task_due_date` in `app/services/task_service.py` was constructing the offset with `timedelta(hours=days)` instead of `timedelta(days=days)`. This meant deferring by 3 days only moved the due date forward by 3 hours.

### Fix
```python
# Before
task.due_date = base_due + timedelta(hours=days)

# After
task.due_date = base_due + timedelta(days=days)
```

### Testing
Deferring a task by N days now correctly advances `due_date` by N × 24 hours (whole days).