### PR TITLE
fix: set completed_at when task is marked as done

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -49,12 +49,9 @@ def update_task(db: Session, task: Task, updates: TaskUpdate) -> Task:
     for field, value in update_data.items():
         setattr(task, field, value)
 
-    # ──────────────────────────────────────────────────────────────────
-    # BUG #1 (Today's demo): When a task is marked as "done", we should
-    # set completed_at = datetime.utcnow(). This line is MISSING.
-    # The status gets updated but completed_at stays None, which breaks
-    # analytics (avg completion time) and overdue detection.
-    # ──────────────────────────────────────────────────────────────────
+    # Set completed_at when a task is marked as done.
+    if task.status == TaskStatus.DONE and task.completed_at is None:
+        task.completed_at = datetime.utcnow()
 
     task.updated_at = datetime.utcnow()
     db.commit()


### PR DESCRIPTION
## Summary

Fixes #1

### Root Cause
`update_task` updated `task.status` to `DONE` but never set `completed_at`, leaving it as `None`. This caused the analytics dashboard to show `null` for average completion time.

### Fix
After applying field updates, if `task.status == TaskStatus.DONE` and `completed_at` is not yet set, assign `datetime.utcnow()`.