### PR TITLE
fix: auto-escalation should not promote HIGH priority to CRITICAL

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -95,16 +95,10 @@ def auto_escalate_priority(db: Session, task: Task) -> Task:
         if task.status in (TaskStatus.DONE, TaskStatus.CANCELLED):
             return task
 
-        # ──────────────────────────────────────────────────────────────
-        # BUG #2 (Future RAG demo): HIGH escalates to CRITICAL here,
-        # but business-rules.md says HIGH should stay HIGH.
-        # An agentic AI would need to retrieve docs/business-rules.md
-        # to understand this is wrong.
-        # ──────────────────────────────────────────────────────────────
         escalation_map = {
             Priority.LOW: Priority.MEDIUM,
             Priority.MEDIUM: Priority.HIGH,
-            Priority.HIGH: Priority.CRITICAL,  # BUG: should stay HIGH
+            # HIGH stays HIGH per business rules; CRITICAL stays CRITICAL (not in map)
         }
 
         new_priority = escalation_map.get(task.priority)


### PR DESCRIPTION
## Summary

Fixes #3

### Root Cause
`auto_escalate_priority` had `Priority.HIGH: Priority.CRITICAL` in the escalation map. Per business rules, HIGH should stay HIGH when overdue — only LOW→MEDIUM and MEDIUM→HIGH are valid escalations.

### Fix
Removed the `HIGH → CRITICAL` entry from `escalation_map`. HIGH and CRITICAL tasks are now unaffected by auto-escalation.