### PR TITLE
fix: reassigning a task no longer resets priority to LOW

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -157,9 +157,6 @@ def reassign_task_owner(db: Session, task: Task, new_owner_id: int) -> Task:
     """Move a task to a different owner."""
     task.owner_id = new_owner_id
 
-    # BUG #5: Reassign should not mutate priority, but this forces LOW.
-    task.priority = Priority.LOW
-
     task.updated_at = datetime.utcnow()
     db.commit()
     db.refresh(task)


### PR DESCRIPTION
## Summary

Fixes #6

### Root Cause
`reassign_task_owner` unconditionally set `task.priority = Priority.LOW` after changing the owner, silently downgrading any task to the lowest priority on reassignment.

### Fix
Removed the erroneous `task.priority = Priority.LOW` line. Priority is now fully preserved when a task is reassigned.