### PR TITLE
fix: set completed_at when task is marked as done

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -49,12 +49,10 @@ def update_task(db: Session, task: Task, updates: TaskUpdate) -> Task:
     for field, value in update_data.items():
         setattr(task, field, value)
 
-    # ──────────────────────────────────────────────────────────────────
-    # BUG #1 (Today's demo): When a task is marked as "done", we should
-    # set completed_at = datetime.utcnow(). This line is MISSING.
-    # The status gets updated but completed_at stays None, which breaks
-    # analytics (avg completion time) and overdue detection.
-    # ──────────────────────────────────────────────────────────────────
+    # Set completed_at when a task is marked as done for the first time.
+    # This is required for analytics (avg completion time) to work correctly.
+    if task.status == TaskStatus.DONE and task.completed_at is None:
+        task.completed_at = datetime.utcnow()
 
     task.updated_at = datetime.utcnow()
     db.commit()


### PR DESCRIPTION
## Problem

When a task is marked as `done`, the `completed_at` field was never set — it remained `None` permanently. This caused `analytics_service.py` to skip every completed task in `_avg_completion_hours()`, making `avg_completion_hours` always return `null` on the analytics dashboard.

## Root Cause

In `update_task()` (`app/services/task_service.py`), the code applied all field updates via `setattr` but had no logic to stamp `completed_at` when `status` transitioned to `DONE`.

## Fix

Added a single guard after the field update loop:

```python
if task.status == TaskStatus.DONE and task.completed_at is None:
    task.completed_at = datetime.utcnow()
```

The `is None` check ensures re-saving an already-completed task does not overwrite the original completion timestamp.

## Test Results

- ✅ `test_complete_task_sets_completed_at` — passes
- ✅ `test_analytics_avg_completion_time` — passes
- ✅ 24/28 tests pass overall (4 pre-existing failures from unrelated bugs #3–#6, not introduced by this change)

Fixes #1